### PR TITLE
add config section to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,14 @@
     "support": {
         "issues": "https://github.com/tenet-ac-za/simplesamlphp-module-sqlattribs/issues",
         "source": "https://github.com/tenet-ac-za/simplesamlphp-module-sqlattribs"
+    },
+    "config": {
+        "preferred-install": {
+            "*": "dist"
+        },
+        "sort-packages": true,
+        "allow-plugins": {
+            "simplesamlphp/composer-module-installer": true
+        }
     }
 }


### PR DESCRIPTION
The option "preferred-install" in composer.json is required to make it possible for this module to be installed in the SimpleSAMLphp modules directory in the vendor directory. Without this option the module will be always installed in the modules folder in the directory where composer.json is.